### PR TITLE
Update buddy.js to 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "buddy.js": "^0.5.1",
+    "buddy.js": "^0.7.1",
     "chalk": "^0.5.1"
   }
 }


### PR DESCRIPTION
Quick update to package.json. :) In reference to https://github.com/eugene-bulkin/grunt-buddyjs/issues/4
- Not technically required for new installs, but would kick people off lower versions. Could you publish a new version on npm?
